### PR TITLE
pulling out special-case checking for BACK key

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -2740,15 +2740,13 @@ public class PApplet extends Activity implements PConstants, Runnable {
     }
 
     handleMethods("keyEvent", new Object[] { event });
-
-    // if someone else wants to intercept the key, they should
-    // set key to zero (or something besides the "ESC").
-    if (event.getAction() == KeyEvent.PRESS &&
-        event.getKeyCode() == android.view.KeyEvent.KEYCODE_BACK) {
-      exit();
-    }
   }
 
+  // overriding android default (which exits the activity) so we can handle exiting ourselves.
+  // Processing users who want something else to happen should override this.
+  public void onBackPressed() {
+	  exit();
+  }
 
   protected void nativeKeyEvent(android.view.KeyEvent event) {
     // event.isPrintingKey() returns false for whitespace and others,
@@ -2774,14 +2772,6 @@ public class PApplet extends Activity implements PConstants, Runnable {
 
     KeyEvent ke = new KeyEvent(event, event.getEventTime(),
                                keAction, keModifiers, key, keyCode);
-
-    // if someone else wants to intercept the key, they should
-    // set key to zero (or something besides the "ESC").
-    if (action == android.view.KeyEvent.ACTION_DOWN) {
-      if (keyCode == android.view.KeyEvent.KEYCODE_BACK) {
-        exit();
-      }
-    }
 
     postEvent(ke);
   }


### PR DESCRIPTION
and just handling it through onBackPressed() instead.

So a user who wants to avoid having the app end with the back button can just override onBackPressed() and do whatever they want to do instead.

Note: submitting an alternate pull request that repairs the originally documented usage of changing keyCode within onKeyPressed().  Probably want to accept one of these and reject the other.
